### PR TITLE
Remove composer installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
 	"license": "Apache",
 	"type": "cakephp-plugin",
 	"require": {
-		"composer/installers": "*"
 	},
 	"require-dev": {
 		"cakephp/cakephp": "3.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,6 @@
 	"keywords": ["CakePHP", "Bootstrap"],
 	"license": "Apache",
 	"type": "cakephp-plugin",
-	"require": {
-	},
 	"require-dev": {
 		"cakephp/cakephp": "3.0.x-dev"
 	},


### PR DESCRIPTION
According to the new logic introduced in cakephp/cakephp#5641 the vendor plugins should be installed into the `vendor` folder and they will be automatically linked with the CakePHP. The `plugins` folder should be used for internall app plugins only.

The [composer/installers](https://github.com/composer/installers) also needs to be updated, but maybe it will be not possible, since the `"type": "cakephp-plugin"` in `composer.json` is also used for 2.x and 3.x plugins and the new logic with the vendor folder is only in 3.x.

But not requiring the [composer/installers](https://github.com/composer/installers) will do the trick. Otherwise it installs all the plugins to the `plugins` folder instead of `vendor` folder.