### PR TITLE
Fix for adding custom class

### DIFF
--- a/src/View/Helper/BootstrapFormHelper.php
+++ b/src/View/Helper/BootstrapFormHelper.php
@@ -69,12 +69,12 @@ class BootstrapFormHelper extends FormHelper {
         $size = $this->_extractOption('bootstrap-size', $options, FALSE);
         unset($options['bootstrap-size']) ;
         unset($options['bootstrap-type']) ;
-        $options = $this->addClass($options, 'btn') ;
+        $options = array_merge_recursive(['class'=>['btn']], $options);
         if (in_array($type, $this->buttonTypes)) {
-            $options = $this->addClass($options, 'btn-'.$type) ;
+            array_splice($options['class'], 1, 0, 'btn-'.$type);
         }
         if (in_array($size, $this->buttonSizes)) {
-            $options = $this->addClass($options, 'btn-'.$size) ;
+            array_splice($options['class'], 1, 0, 'btn-'.$size);
         }
         return $options ;
     }
@@ -125,13 +125,13 @@ class BootstrapFormHelper extends FormHelper {
         $this->inline = $this->_extractOption('inline', $options, false) ;
         unset($options['inline']) ;
 		if ($this->horizontal) {
-			$options = $this->addClass($options, 'form-horizontal') ;
+			$options = array_merge_recursive(['class'=>['form-horizonta']], $options);
 		}
         else if ($this->inline) {
-            $options = $this->addClass($options, 'form-inline') ;
+            $options = array_merge_recursive(['class'=>['form-inline']], $options);
         }
         if ($this->search) {
-            $options = $this->addClass($options, 'form-search') ;
+            $options = array_merge_recursive(['class'=>['form-search']], $options);
         }
         $options['role'] = 'form' ;
         $this->templates([
@@ -264,7 +264,7 @@ class BootstrapFormHelper extends FormHelper {
         $block = $this->_extractOption('bootstrap-block', $options, false) ;
         unset($options['bootstrap-block']);
         if ($block) {
-            $options = $this->addClass($options, 'btn-block') ;
+            $options = array_merge_recursive(['class'=>['btn-block']], $options);
         }
         return $options ;
     }
@@ -296,9 +296,9 @@ class BootstrapFormHelper extends FormHelper {
     public function buttonGroup ($buttons, array $options = array()) {
         $vertical = $this->_extractOption('vertical', $options, false) ;
         unset($options['vertical']) ;
-        $options = $this->addClass($options, 'btn-group') ;
+        $options = array_merge_recursive(['class'=>['btn-group']], $options);
         if ($vertical) {
-            $options = $this->addClass($options, 'btn-group-vertical') ;
+            array_splice($options['class'], 1, 0, 'btn-group-vertical');
         }
         return $this->Html->tag('div', implode('', $buttons), $options) ;
     }
@@ -312,7 +312,7 @@ class BootstrapFormHelper extends FormHelper {
      * 
     **/
     public function buttonToolbar (array $buttonGroups, array $options = array()) {
-        $options = $this->addClass($options, 'btn-toolbar') ;
+        $options = array_merge_recursive(['class'=>['btn-toolbar']], $options);
         return $this->Html->tag('div', implode('', $buttonGroups), $options) ;
     }
     
@@ -330,7 +330,7 @@ class BootstrapFormHelper extends FormHelper {
     
         $options['type'] = false ;
         $options['data-toggle'] = 'dropdown' ;
-        $options = $this->addClass($options, "dropdown-toggle") ;
+        $options = array_merge_recursive(['class'=>['dropdown-toggle']], $options);
         
         $outPut = '<div class="btn-group">' ;
         $outPut .= $this->button($title.' <span class="caret"></span>', $options) ;

--- a/src/View/Helper/BootstrapHtmlHelper.php
+++ b/src/View/Helper/BootstrapHtmlHelper.php
@@ -88,8 +88,8 @@ class BootstrapHtmlHelper extends HtmlHelper {
         $type = $this->_extractType($options, 'type', $default = 'default',
                     array('default', 'primary', 'success', 'warning', 'info', 'danger')) ;
         unset ($options['type']) ;
-        $options = $this->addClass($options, 'label') ;
-        $options = $this->addClass($options, 'label-'.$type) ;
+        $options = array_merge_recursive(['class'=>['label']], $options);
+        array_splice($options['class'], 1, 0, 'label-'.$type);
         return $this->tag('span', $text, $options) ;
     }
     
@@ -103,7 +103,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
      *
     **/
     public function badge ($text, $options = array()) {
-        $options = $this->addClass($options, 'badge') ;
+        $options = array_merge_recursive(['class'=>['badge']], $options);
         return $this->tag('span', $text, $options) ;
     }
 
@@ -119,7 +119,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
     **/
     public function getCrumbList(array $options = array(), $startText = false) {
         $options['separator'] = '' ;
-        $options = $this->addClass($options, 'breadcrumb') ;
+        $options = array_merge_recursive(['class'=>['breadcrumb']], $options);
         return parent::getCrumbList ($options, $startText) ;
     }
     
@@ -149,9 +149,9 @@ class BootstrapHtmlHelper extends HtmlHelper {
         $button = '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>' ;
         $type = $this->_extractType($options, 'type', 'warning', array('info', 'warning', 'success', 'danger')) ;
         unset($options['type']) ;
-        $options = $this->addClass($options, 'alert') ;
+        $options = array_merge_recursive(['class'=>['alert']], $options);
         if ($type) {
-            $options = $this->addClass($options, 'alert-'.$type) ;
+            array_splice($options['class'], 1, 0, 'alert-'.$type);
         }
         $class = $options['class'] ;
         unset($options['class']) ;
@@ -220,12 +220,12 @@ class BootstrapHtmlHelper extends HtmlHelper {
                 'style' => 'width: '.$widths.'%;'
             )) ;
         }
-        $options = $this->addClass($options, 'progress') ;
+        $options = array_merge_recursive(['class'=>['progress']], $options);
         if ($active) {
-            $options = $this->addClass($options, 'active') ;
+            array_splice($options['class'], 1, 0, 'active');
         }
         if ($striped) {
-            $options = $this->addClass($options, 'progress-striped') ;
+            array_splice($options['class'], 1, 0, 'progress-striped');
         }
         $classes = $options['class'];
         unset($options['class']) ;


### PR DESCRIPTION
Cakephp allows adding classes like this;
$this->Form->button("Login", ['class'=>['foo','bar']])

But with your plugin that is not possible.
 $this->Form->button("Login", ['bootstrap-type' => 'success','class'=>['foo','bar']])
You can also do this:
 $this->Form->button("Login", ['bootstrap-type' => 'success','class'=>['foo bar']])
Or:
 $this->Form->button("Login", ['bootstrap-type' => 'success','class'=>'foo bar'])

Now with this fix this work.
