### PR TITLE
Require stable CakePHP 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
 	"keywords": ["CakePHP", "Bootstrap"],
 	"license": "Apache",
 	"type": "cakephp-plugin",
-	"require-dev": {
-		"cakephp/cakephp": "3.0.x-dev"
+	"require": {
+		"cakephp/cakephp": "~3.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Since the CakePHP is now in stable 3.0 version, require this one instead of the dev.