### PR TITLE
Makes the custom file input "multiple-files-friendly"

### DIFF
--- a/src/View/Helper/BootstrapFormHelper.php
+++ b/src/View/Helper/BootstrapFormHelper.php
@@ -451,9 +451,10 @@ class BootstrapFormHelper extends FormHelper {
         $options += ['secure' => true];
         $options = $this->_initInputField($fieldName, $options);
         unset($options['type']);
+        $countLabel = $this->_extractOption('count-label', $options, __('files selected'));
         $fileInput = $this->widget('file', array_merge($options, [
             'style' => 'display: none;',
-            'onchange' => "document.getElementById('".$options['id']."-input').value = this.files[0].name;"
+            'onchange' => "document.getElementById('".$options['id']."-input').value = (this.files.length <= 1) ? this.files[0].name : this.files.length + ' ' + '" . $countLabel . "';"
         ]));
         $fakeInput = $this->text($fieldName, array_merge($options, [
             'readonly' => 'readonly',


### PR DESCRIPTION
Instead of only displaying the first file upload, it will show a count if multiple files have been selected.
Changes are on line 454 to 457