### PR TITLE
Allow Bootstrap modal sizes

### DIFF
--- a/src/View/Helper/BootstrapModalHelper.php
+++ b/src/View/Helper/BootstrapModalHelper.php
@@ -64,7 +64,25 @@ class BootstrapModalHelper extends Helper {
             $this->currentId = $options['id'] ;
             $options['aria-labbeledby'] = $this->currentId.'Label' ;
         }
-		$res = $this->Html->div('modal fade '.$this->_extractOption('class', $options, ''), NULL, $options).$this->Html->div('modal-dialog').$this->Html->div('modal-content');
+        $options['size'] = $this->_extractOption('size', $options, '');
+	switch($options['size']) {
+		case 'lg':
+		case 'large':
+		case 'modal-lg':
+			$size = ' modal-lg';
+			break;
+		case 'sm':
+		case 'small':
+		case 'modal-sm':
+			$size = ' modal-lg';
+			break;
+		default:
+			$size = '';
+			break;
+	}
+	unset($options['size']);
+        
+	$res = $this->Html->div('modal fade '.$this->_extractOption('class', $options, ''), NULL, $options).$this->Html->div('modal-dialog'.$size).$this->Html->div('modal-content');
         if (is_string($title) && $title) {
             $res .= $this->_createHeader($title, array('close' => $close)) ;
             if (!$nobody) {


### PR DESCRIPTION
Allows the use of the Bootstrap modal size classes. Either .modal-lg or .modal-sm can be added to the .modal-dialog div.

See http://getbootstrap.com/javascript/#modals-sizes