### PR TITLE
Allow dropdowns be wrapped with any tag

### DIFF
--- a/src/View/Helper/BootstrapHtmlHelper.php
+++ b/src/View/Helper/BootstrapHtmlHelper.php
@@ -24,7 +24,7 @@ namespace Bootstrap3\View\Helper;
 
 use Cake\View\Helper\HtmlHelper;
 
-class BootstrapHtmlHelper extends HtmlHelper {    
+class BootstrapHtmlHelper extends HtmlHelper {
 
     /**
      * Use font awesome icons instead of glyphicons.
@@ -46,7 +46,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
         }
         return $default ;
     }
-    
+
     /**
      * Adds the given class to the element options
      *
@@ -73,15 +73,15 @@ class BootstrapHtmlHelper extends HtmlHelper {
         }
         return $options ;
     }
-    
+
     /**
-     * 
+     *
      * Check type values in $options, returning null if no option is found or if
-     * option is not in $avail. 
+     * option is not in $avail.
      * If type == $default, $default is returned (even if it is not in $avail).
-     * 
+     *
     **/
-    protected function _extractType ($options, $key = 'type', $default = 'info', 
+    protected function _extractType ($options, $key = 'type', $default = 'info',
                                       $avail = array('info', 'success', 'warning', 'error')) {
         $type = $this->_extractOption($key, $options, $default) ;
         if ($default !== false && $type == $default) {
@@ -94,16 +94,16 @@ class BootstrapHtmlHelper extends HtmlHelper {
     }
 
     /**
-     * 
+     *
      * Create a glyphicon or font awesome icon depending on $this->_useFontAwesome.
-     * 
+     *
      * @param $icon Name of the icon.
-     * 
+     *
     **/
     public function icon ($icon) {
         return $this->_useFontAwesome ? $this->faIcon($icon) : $this->glIcon($icon);
     }
-    
+
     /**
      * Create a font awesome icon.
      *
@@ -125,11 +125,11 @@ class BootstrapHtmlHelper extends HtmlHelper {
     /**
      *
      * Create a Twitter Bootstrap span label.
-     * 
+     *
      * @param text The label text
      * @param type The label type (default, primary, success, warning, info, danger)
      * @param options Options for span
-     * 
+     *
      * The second parameter may either be $type or $options (in this case, the third parameter
      * is useless, and the label type can be specified in the $options array).
      *
@@ -151,11 +151,11 @@ class BootstrapHtmlHelper extends HtmlHelper {
         $options = $this->addClass($options, 'label-'.$type) ;
         return $this->tag('span', $text, $options) ;
     }
-    
+
     /**
      *
      * Create a Twitter Bootstrap span badge.
-     * 
+     *
      * @param text The badge text
      * @param options Options for span
      *
@@ -167,12 +167,12 @@ class BootstrapHtmlHelper extends HtmlHelper {
     }
 
     /**
-     * 
+     *
      * Get crumb lists in a HTML list, with bootstrap like style.
      *
      * @param $options Options for list
      * @param $startText Text to insert before list
-     * 
+     *
      * Unusable options:
      * 	- Separator
     **/
@@ -181,22 +181,22 @@ class BootstrapHtmlHelper extends HtmlHelper {
         $options = $this->addClass($options, 'breadcrumb') ;
         return parent::getCrumbList ($options, $startText) ;
     }
-    
+
     /**
-     *  
+     *
      * Create a Twitter Bootstrap style alert block, containing text.
-     *  
+     *
      * @param $text The alert text
      * @param $type The type of the alert
      * @param $options Options that will be passed to Html::div method
      *
      * The second parameter may either be $type or $options (in this case, the third parameter
      * is useless, and the label type can be specified in the $options array).
-     * 
+     *
      * Available BootstrapHtml options:
-     * 	- type: string, type of alert (default, error, info, success ; useless if 
+     * 	- type: string, type of alert (default, error, info, success ; useless if
      *    $type is specified)
-     *     
+     *
     **/
     public function alert ($text, $type = 'warning', $options = array()) {
         if (is_string($type)) {
@@ -216,28 +216,28 @@ class BootstrapHtmlHelper extends HtmlHelper {
         unset($options['class']) ;
         return $this->div($class, $button.$text, $options) ;
     }
-    
+
     /**
-     * 
+     *
      * Create a Twitter Bootstrap style progress bar.
-     * 
-     * @param $widths 
+     *
+     * @param $widths
      * 	- The width (in %) of the bar (style primary, without display)
-     * 	- An array of bar, with (for each bar) : 
+     * 	- An array of bar, with (for each bar) :
      *        - width (only field required)
      *        - type (primary, info, danger, success, warning, default is primary)
      *        - min (integer, default 0)
      *        - max (integer, default 100)
      *        - display (boolean, default false, for text display)
      * @param $options Options that will be passed to Html::div method (only for main div)
-     *  
+     *
      * If $widths is only a integer (first case), $options may contains value for the fields
      * specified above.
      *
      * Available BootstrapHtml options:
      * 	- striped: boolean, specify if progress bar should be striped
      * 	- active: boolean, specify if progress bar should be active
-     *     
+     *
     **/
     public function progress ($widths, $options = array()) {
         $striped = $this->_extractOption('striped', $options, false) || in_array('striped', $options);
@@ -256,7 +256,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
                     'aria-valuenow' => $w['width'],
                     'aria-valuemin' => $min,
                     'aria-valuemax' => $max,
-                    'role' => 'progressbar', 
+                    'role' => 'progressbar',
                     'style' => 'width: '.$w['width'].'%;'
                 )) ;
             }
@@ -275,7 +275,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
                 'aria-valuenow' => $widths,
                 'aria-valuemin' => $min,
                 'aria-valuemax' => $max,
-                'role' => 'progressbar', 
+                'role' => 'progressbar',
                 'style' => 'width: '.$widths.'%;'
             )) ;
         }
@@ -290,15 +290,15 @@ class BootstrapHtmlHelper extends HtmlHelper {
         unset($options['class']) ;
         return $this->div($classes, $bars, $options) ;
     }
-    
+
     /**
-     * 
+     *
      * Create & return a twitter bootstrap dropdown menu.
-     * 
+     *
      * @param $menu HTML tags corresponding to menu options (which will be wrapped
      * 		 into <li> tag). To add separator, pass 'divider'.
      * @param $options Options for the ul tag.
-     * 
+     *
      */
     public function dropdown (array $menu = [], array $options = []) {
         $output = '' ;
@@ -327,7 +327,10 @@ class BootstrapHtmlHelper extends HtmlHelper {
         }
         $options = $this->addClass($options, 'dropdown-menu');
         $options['role'] = 'menu' ;
-        return $this->div(null, $output, $options) ;
+        $options += ['tag' => 'div'];
+        $tag = $options['tag'];
+        unset($options['tag']);
+        return $this->tag($tag, $output, $options) ;
     }
 
     /**
@@ -338,7 +341,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
      *
      * @param $breakIndex int|string divisible index that will trigger a new row
      * @param $data array collection of data used to render each column
-     * @param $determineContent callable a callback that will be called with the 
+     * @param $determineContent callable a callback that will be called with the
      * data required to render an individual column
      * @return string
      */
@@ -360,7 +363,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
         return $rowsHtml;
 
     }
-    
+
 }
 
 ?>

--- a/src/View/Helper/BootstrapHtmlHelper.php
+++ b/src/View/Helper/BootstrapHtmlHelper.php
@@ -297,7 +297,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
      *
      * @param $menu HTML tags corresponding to menu options (which will be wrapped
      * 		 into <li> tag). To add separator, pass 'divider'.
-     * @param $options Options for the ul tag.
+     * @param $options Attributes for the wrapper (change it with tag)
      *
      */
     public function dropdown (array $menu = [], array $options = []) {


### PR DESCRIPTION
This is useful when making [navbars](http://getbootstrap.com/components/#navbar), the have to be in ul, not in a div.