### PR TITLE
Added a function to create nav's for navbar's

### DIFF
--- a/src/View/Helper/BootstrapHtmlHelper.php
+++ b/src/View/Helper/BootstrapHtmlHelper.php
@@ -352,7 +352,7 @@ class BootstrapHtmlHelper extends HtmlHelper {
                     'aria-haspopup' => 'true',
                     'aria-expanded' => 'false'
                 ];
-                $li_options = [];
+                $li_options = ['caret' => true];
                 if (array_key_exists('_options', $submenu) && is_array($submenu['_options'])) {
                     if (array_key_exists('dropdown', $submenu['_options'])) {
                         $dropdown_options += $submenu['_options']['dropdown'];
@@ -368,9 +368,20 @@ class BootstrapHtmlHelper extends HtmlHelper {
                     unset($submenu['_options']);
                 }
 
+                $caret = '';
+                if ($li_options['caret'] === TRUE) {
+                    $caret = ' <span class="caret"></span>';
+                } elseif ($li_options['caret'] === FALSE) {
+                    $caret = '';
+                } else {
+                    $caret = $li_options['caret'];
+                }
+                unset($li_options['caret']);
+
                 $output .= $this->tag(
                     'li',
-                    $this->link($item, '#', $link_options).$this->dropdown($submenu, $dropdown_options),
+                    $this->link($item.$caret, '#', $link_options).
+                    $this->dropdown($submenu, $dropdown_options),
                     $li_options
                 );
             }

--- a/src/View/Helper/BootstrapHtmlHelper.php
+++ b/src/View/Helper/BootstrapHtmlHelper.php
@@ -338,6 +338,50 @@ class BootstrapHtmlHelper extends HtmlHelper {
         return $this->tag($tag, $output, $options) ;
     }
 
+    public function navbarNav(array $menu = [], array $options = []) {
+        $output = '';
+        foreach ($menu as $item => $submenu) {
+            if ($item === 'divider' || (is_array($item) && $item[0] === 'divider')) {
+                $output .= '<li role="presentation" class="divider"></li>' ;
+            }
+            elseif (is_array($submenu)) {
+                $dropdown_options = ['tag' => 'ul'];
+                $link_options = [
+                    'data-toggle' => 'dropdown',
+                    'role' => 'button',
+                    'aria-haspopup' => 'true',
+                    'aria-expanded' => 'false'
+                ];
+                $li_options = [];
+                if (array_key_exists('_options', $submenu) && is_array($submenu['_options'])) {
+                    if (array_key_exists('dropdown', $submenu['_options'])) {
+                        $dropdown_options += $submenu['_options']['dropdown'];
+                        $dropdown_options = $this->addClass($dropdown_options, 'dropdown-menu');
+                    }
+                    if (array_key_exists('link', $submenu['_options'])) {
+                        $link_options += $submenu['_options']['link'];
+                        $link_options = $this->addClass($link_options, 'dropdown-toggle');
+                    }
+                    if (array_key_exists('li', $submenu['_options'])) {
+                        $li_options += $submenu['_options']['li'];
+                    }
+                    unset($submenu['_options']);
+                }
+
+                $output .= $this->tag(
+                    'li',
+                    $this->link($item, '#', $link_options).$this->dropdown($submenu, $dropdown_options),
+                    $li_options
+                );
+            }
+            else {
+                $output .= '<li>'.$submenu.'</li>' ;
+            }
+        }
+        $options = ['tag' => 'ul', 'class' => 'nav navbar-nav'] + $options;
+        return $this->tag($options['tag'], $output, $options);
+    }
+
     /**
      * Create a formatted collection of elements while
      * maintaining proper bootstrappy markup. Useful when

--- a/src/View/Helper/BootstrapHtmlHelper.php
+++ b/src/View/Helper/BootstrapHtmlHelper.php
@@ -316,9 +316,14 @@ class BootstrapHtmlHelper extends HtmlHelper {
                     }
                     $name = array_shift($action) ;
                     $url  = array_shift($action) ;
+                    $li_options = ['role' => 'presentation'];
+                    if (array_key_exists('_options', $action)) {
+                        $li_options += $action['_options'];
+                        unset($action['_options']);
+                    }
                     $action['role'] = 'menuitem' ;
                     $action['tabindex'] = -1 ;
-                    $output .= '<li role="presentation">'.$this->link($name, $url, $action).'</li>';
+                    $output .= $this->tag('li', $this->link($name, $url, $action), $li_options);
                 }
             }
             else {


### PR DESCRIPTION
For example the following code
```
<nav class="navbar navbar-default navbar-fixed-top">
    <div class="container-fluid">
        <div class="navbar-header">
            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse">
                <span class="sr-only">Toggle navigation</span>
                <span class="icon-bar"></span>
                <span class="icon-bar"></span>
                <span class="icon-bar"></span>
          </button>
          <a class="navbar-brand" href="/">Book Marketer</a>
        </div>
        <div class="collapse navbar-collapse" id="navbar-collapse">
<?php
echo $this->Html->navbarNav(
    [
        'Books' => [
            [
                'link',
                'Books',
                ['controller' => 'Books', 'action' => 'index'],
                '_options' => ['class' => $this->name == 'Books' ? 'active' : '', 'escape' => false]
            ],
            [
                'link',
                'Tags',
                ['controller' => 'Tags', 'action' => 'index'],
                '_options' => ['class' => $this->name == 'Tags' ? 'active' : '', 'escape' => false]
            ],
            '_options' => [
                'li' => ['class' => ($this->name == 'Books' || $this->name == 'Tags') ? 'active' : ''],
                'link' => ['escape' => false]
            ]
        ],
        $this->Html->tag('p', 'Signed as Mark Otto', ['class' => 'navbar-text'])
    ],
    ['escape' => false]
);
?>
        </div>
    </div>
</nav>
```

Will produce the next result
![screenshot_20150722_004839](https://cloud.githubusercontent.com/assets/7199046/8817603/8e254f08-300b-11e5-861b-ce11b063d857.png)
allowing to add atributes to the li item, the link and the dropdown.

Maybe it need's some testing and some code review. Tried to be as clean as posible